### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server for searching [barnsworthburning.net](https://barnsworthburning.net).
 
+<a href="https://glama.ai/mcp/servers/5aibjjzkkb">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/5aibjjzkkb/badge" alt="Barnsworthburning MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides a tool for searching barnsworthburning.net through the API endpoint at `https://barnsworthburning.net/api/search`. It can be used with Claude for Desktop or any other MCP client.


### PR DESCRIPTION
This PR adds a badge for the [Barnsworthburning MCP](https://glama.ai/mcp/servers/5aibjjzkkb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5aibjjzkkb">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/5aibjjzkkb/badge" alt="Barnsworthburning MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.